### PR TITLE
Add service file for systemd and Environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This is a template which can be used to monitor oVirt or libvirt virtualization 
 
 The template was exported from Zabbix version 2.4.3
 Tested with oVirt version 3.5.0.1 release 1.el6, libvirt version 0.10.2 release 46.el6_6.2 on CentOS 6.6
+Tester with oVirt version 3.5.5 on CentOS 7.1 with systemd service files
 
 ## How to use:
 1. Enable SNMP on the oVirt or libvirt host

--- a/libvirtMib
+++ b/libvirtMib
@@ -1,0 +1,1 @@
+LIBVIRT_DEFAULT_URI=qemu+unix:///system?socket=/run/libvirt/libvirt-sock-ro

--- a/libvirtMib.service
+++ b/libvirtMib.service
@@ -3,7 +3,7 @@ Description=libvirtMib SubAgent for SNMP
 
 [Service]
 Type=forking
-EnvironmentFile=/etc/sysconfig/libvirtMib
+EnvironmentFile=-/etc/sysconfig/libvirtMib
 ExecStart=/bin/sh -c 'LIBVIRT_DEFAULT_URI=${LIBVIRT_DEFAULT_URI} /usr/bin/libvirtMib_subagent'
 
 [Install]

--- a/libvirtMib.service
+++ b/libvirtMib.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=libvirtMib SubAgent for SNMP
+
+[Service]
+Type=forking
+EnvironmentFile=/etc/sysconfig/libvirtMib
+ExecStart=/bin/sh -c 'LIBVIRT_DEFAULT_URI=${LIBVIRT_DEFAULT_URI} /usr/bin/libvirtMib_subagent'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
With this files , you can use it on CentOS 7.1 without modify libvirtd.conf (not recommanded by ovirt Team).
